### PR TITLE
x-correlation-id and gcloud trace by default in all loggers

### DIFF
--- a/src/nestjs-pino-context/example/src/example.api.ts
+++ b/src/nestjs-pino-context/example/src/example.api.ts
@@ -2,10 +2,18 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { ExampleModule } from './example.module';
 import { GcloudTraceService } from '../../../nestjs-gcloud-trace/src';
-import { createLoggerTool } from '../../src';
+import {
+  createLoggerTool,
+  PinoContextLogger,
+  PinoContextConfig,
+} from '../../src';
+import { loggerConfig } from './logger.config';
 
 async function bootstrap() {
-  const app = await NestFactory.create(ExampleModule);
+  const logger = new PinoContextLogger(new PinoContextConfig(loggerConfig));
+  const app = await NestFactory.create(ExampleModule, {
+    logger,
+  });
   app.useLogger(createLoggerTool(app));
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/nestjs-pino-context/example/src/example.module.ts
+++ b/src/nestjs-pino-context/example/src/example.module.ts
@@ -1,62 +1,18 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
-import { Request } from 'express';
 import { CorrelationIdModule } from '../../../nestjs-correlation-id/src';
 import { GcloudTraceModule } from '../../../nestjs-gcloud-trace/src';
-import { PinoContextModule, PredefinedConfig } from '../../src';
+import { PinoContextModule } from '../../src';
 import { ExampleController } from './example.controller';
 import { ExampleHandler } from './command/handler/example.handler';
-
-const config =
-  process.env.NODE_ENV !== 'production'
-    ? {
-        base: PredefinedConfig.STACKDRIVER,
-        logFieldNames: {
-          trace: 'error',
-        },
-        labels: {
-          env: [
-            {
-              label: 'project',
-              value: 'example',
-            },
-            { label: 'node-env', path: 'NODE_ENV' },
-          ],
-          request: [
-            {
-              label: 'content-type',
-              pick: { headers: ['content-type'] },
-            },
-            {
-              label: 'visible-if-fallback-id',
-              pick: { query: ['fallback-id'], body: ['not-shown'] },
-            },
-            {
-              label: 'entity-id',
-              pick: [
-                { body: ['id'], params: ['id'] },
-                {
-                  body: ['override-id'],
-                  filter: (req: Request) => !req.body['block-override'],
-                },
-              ],
-            },
-            {
-              label: 'deep-in-body',
-              pick: [{ body: ['deep.id'] }],
-              path: 'deep-in-body.id',
-            },
-          ],
-        },
-      }
-    : PredefinedConfig.STACKDRIVER;
+import { loggerConfig } from './logger.config';
 
 @Module({
   imports: [
     CorrelationIdModule.register(),
     GcloudTraceModule,
     CqrsModule,
-    PinoContextModule.register(config),
+    PinoContextModule.register(loggerConfig),
   ],
   controllers: [ExampleController],
   providers: [ExampleHandler],

--- a/src/nestjs-pino-context/example/src/logger.config.ts
+++ b/src/nestjs-pino-context/example/src/logger.config.ts
@@ -1,0 +1,46 @@
+import { Request } from 'express';
+import { PredefinedConfig } from '../../src/enums';
+
+export const loggerConfig =
+  process.env.NODE_ENV !== 'production'
+    ? {
+        base: PredefinedConfig.STACKDRIVER,
+        logFieldNames: {
+          trace: 'error',
+        },
+        labels: {
+          env: [
+            {
+              label: 'project',
+              value: 'example',
+            },
+            { label: 'node-env', path: 'NODE_ENV' },
+          ],
+          request: [
+            {
+              label: 'content-type',
+              pick: { headers: ['content-type'] },
+            },
+            {
+              label: 'visible-if-fallback-id',
+              pick: { query: ['fallback-id'], body: ['not-shown'] },
+            },
+            {
+              label: 'entity-id',
+              pick: [
+                { body: ['id'], params: ['id'] },
+                {
+                  body: ['override-id'],
+                  filter: (req: Request) => !req.body['block-override'],
+                },
+              ],
+            },
+            {
+              label: 'deep-in-body',
+              pick: [{ body: ['deep.id'] }],
+              path: 'deep-in-body.id',
+            },
+          ],
+        },
+      }
+    : PredefinedConfig.STACKDRIVER;

--- a/src/nestjs-pino-context/src/config/stackdriver.config.ts
+++ b/src/nestjs-pino-context/src/config/stackdriver.config.ts
@@ -1,6 +1,4 @@
 import { LoggerOptions, PrettyOptions } from 'pino';
-import { LogFieldsConfigPartContextType } from '../types';
-import { LogFieldsConfigKey } from '../enums';
 
 /**
  * @todo check if it's interesting to trace correlation-id logs in the same
@@ -30,16 +28,6 @@ export const loggerOptions = {
 } as LoggerOptions;
 
 export const stackdriver = {
-  // if any of correlation-id or gcloud-trace modules are includes,
-  // their label and field will automatically be added
-  [LogFieldsConfigKey.FIELDS]: {
-    context: [
-      'logging.googleapis.com/trace',
-    ] as LogFieldsConfigPartContextType[],
-  },
-  [LogFieldsConfigKey.LABELS]: {
-    context: ['x-correlation-id'] as LogFieldsConfigPartContextType[],
-  },
   logFieldNames: {
     context: 'context',
     labels: 'labels',

--- a/src/nestjs-pino-context/src/pino-context.config.ts
+++ b/src/nestjs-pino-context/src/pino-context.config.ts
@@ -5,6 +5,7 @@ import {
   ModuleRegisterType,
   PredefinedConfigDescriptorType,
   LogFieldsConfigType,
+  LogFieldsConfigPartContextType,
 } from './types';
 import { isPredefinedLogger, isCustomLogger } from './type-guards';
 import { LogFieldsConfigKey } from './enums';
@@ -19,17 +20,21 @@ export class PinoContextConfig implements ConfigType {
   [LogFieldsConfigKey.FIELDS]: Required<LogFieldsConfigType> = {
     env: [],
     request: [],
-    context: [],
+    // if nestjs-gcloud-trace module is being imported, the trace will be added as field
+    context: [
+      'logging.googleapis.com/trace',
+    ] as LogFieldsConfigPartContextType[],
   };
   [LogFieldsConfigKey.LABELS]: Required<LogFieldsConfigType> = {
     env: [],
     request: [],
-    context: [],
+    // if nestjs-correlation-id module is being imported, the x-correlation-id will be added as label
+    context: ['x-correlation-id'] as LogFieldsConfigPartContextType[],
   };
   loggerOptions = {};
   logFieldNames = defaultLogFieldNames;
 
-  constructor(config: ModuleRegisterType = configs.stackdriver) {
+  constructor(config: ModuleRegisterType = {}) {
     let configToMerge: ConfigType = {};
     if (isPredefinedLogger(config)) {
       configToMerge = configs[config] as ConfigType;

--- a/src/nestjs-pino-context/src/pino-context.module.ts
+++ b/src/nestjs-pino-context/src/pino-context.module.ts
@@ -1,41 +1,42 @@
-import { DynamicModule, Module, Provider } from '@nestjs/common';
+import { DynamicModule, Module } from '@nestjs/common';
 import { DiscoveryModule, APP_INTERCEPTOR } from '@nestjs/core';
 import { ContextModule } from '../../nestjs-context';
 
 import { PinoContextLogger } from './pino-context-logger.service';
-import { ConfigType, ModuleRegisterType } from './types';
+import { ModuleRegisterType } from './types';
 import { PinoContextRequestInterceptor } from './pino-context-request.interceptor';
 import { PinoContextConfig } from './pino-context.config';
 import { SetContextForLoggerInstancesExplorer } from './set-context-for-logger-instances.explorer';
 
-@Module({
+const moduleDef = {
   imports: [DiscoveryModule, ContextModule.register()],
-})
+  providers: [
+    SetContextForLoggerInstancesExplorer,
+    {
+      provide: PinoContextConfig,
+      useValue: new PinoContextConfig({}),
+    },
+    PinoContextLogger,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: PinoContextRequestInterceptor,
+    },
+  ],
+  exports: [PinoContextLogger, PinoContextConfig],
+};
+
+@Module(moduleDef)
 export class PinoContextModule {
-  static forRoot(config?: ModuleRegisterType): DynamicModule {
-    return PinoContextModule.register(config);
-  }
-
-  static register(configModule?: ModuleRegisterType): DynamicModule {
+  static register(configModule: ModuleRegisterType = {}): DynamicModule {
     const config = new PinoContextConfig(configModule);
-
-    const ConfigProvider: Provider<ConfigType> = {
+    const ConfigProvider = {
       provide: PinoContextConfig,
       useValue: config,
     };
-
     return {
       module: PinoContextModule,
-      providers: [
-        SetContextForLoggerInstancesExplorer,
-        ConfigProvider,
-        PinoContextLogger,
-        {
-          provide: APP_INTERCEPTOR,
-          useClass: PinoContextRequestInterceptor,
-        },
-      ],
-      exports: [PinoContextLogger, PinoContextConfig],
+      ...moduleDef,
+      providers: [...moduleDef.providers, ConfigProvider],
     };
   }
 }


### PR DESCRIPTION
All the loggers (not only stackdriver) will include by default x-correlation-id label and gcloud trace field if we include and configure the corresponding modules.
Updated Readme and examples.